### PR TITLE
telemetry: phase-6 – panic recovery

### DIFF
--- a/docs/telemetry-planning.md
+++ b/docs/telemetry-planning.md
@@ -115,7 +115,7 @@ Each phase is independent; merge on green CI.
 - [x] **Phase 4** – instrument `writePump` (span, counters, bytes).
 - [x] **Phase 4b** – error counter in `run()` default drop path.
 - [ ] **Phase 5** – wrap gRPC server with `otelgrpc` interceptor.
-- [ ] **Phase 6** – panic recovery middleware + `go_panic_total`.
+- [x] **Phase 6** – panic recovery middleware + `go_panic_total`.
 - [ ] Build & run **docker-compose telemetry demo**; validate metrics & traces.
 - [ ] Commit dashboards JSON & PrometheusRule manifests to `deploy/telemetry/`.
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,20 @@ func isTelemetryPhase5Enabled() bool {
 	}
 }
 
+// isTelemetryPhase6Enabled checks if telemetry phase 6 is enabled via environment variable.
+// It follows the same boolean conventions as other phases.
+func isTelemetryPhase6Enabled() bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv("TELEMETRY_PHASE_6_ENABLED")))
+	switch value {
+	case "true", "1", "yes", "on", "enable":
+		return true
+	case "", "false", "0", "no", "off", "disable":
+		return false
+	default:
+		return false
+	}
+}
+
 func main() {
 
 	// Create a context that is canceled when the program receives an interrupt signal
@@ -109,10 +123,16 @@ func main() {
 		mux.Handle(cfg.Metrics.Endpoint, metricsMux)
 	}
 
+	// Wrap with panic recovery middleware if phase 6 is enabled
+	handler := http.Handler(mux)
+	if isTelemetryPhase6Enabled() {
+		handler = telemetry.RecoveryMiddleware(handler)
+	}
+
 	// Start the HTTP server
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.HTTPPort),
-		Handler: mux,
+		Handler: handler,
 	}
 	go func() {
 		log.Printf("Starting HTTP server on port %d", cfg.HTTPPort)

--- a/telemetry/recover.go
+++ b/telemetry/recover.go
@@ -1,0 +1,34 @@
+package telemetry
+
+import (
+	"log"
+	"net/http"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+var panicTotal metric.Int64Counter
+
+func init() {
+	var err error
+	panicTotal, err = Counter("go_panic_total")
+	if err != nil {
+		log.Printf("telemetry counter init failed: %v", err)
+	}
+}
+
+// RecoveryMiddleware recovers from panics in HTTP handlers and records a metric.
+func RecoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				if panicTotal != nil {
+					panicTotal.Add(r.Context(), 1)
+				}
+				log.Printf("panic recovered: %v", rec)
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/telemetry/recover.go
+++ b/telemetry/recover.go
@@ -3,18 +3,25 @@ package telemetry
 import (
 	"log"
 	"net/http"
+	"sync"
 
 	"go.opentelemetry.io/otel/metric"
 )
 
-var panicTotal metric.Int64Counter
+var (
+	panicTotal     metric.Int64Counter
+	initPanicOnce  sync.Once
+)
 
-func init() {
-	var err error
-	panicTotal, err = Counter("go_panic_total")
-	if err != nil {
-		log.Printf("telemetry counter init failed: %v", err)
-	}
+// initPanicCounter initializes the panic counter lazily
+func initPanicCounter() {
+	initPanicOnce.Do(func() {
+		var err error
+		panicTotal, err = Counter("go_panic_total")
+		if err != nil {
+			log.Printf("telemetry counter init failed: %v", err)
+		}
+	})
 }
 
 // RecoveryMiddleware recovers from panics in HTTP handlers and records a metric.
@@ -22,6 +29,8 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if rec := recover(); rec != nil {
+				// Initialize the counter lazily on first use
+				initPanicCounter()
 				if panicTotal != nil {
 					panicTotal.Add(r.Context(), 1)
 				}


### PR DESCRIPTION
## Summary
- add RecoveryMiddleware to capture panics and increment `go_panic_total`
- gate the middleware behind `TELEMETRY_PHASE_6_ENABLED`
- document phase 6 completion in telemetry plan

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_685bc5549aa48322b6af26fd7f41eecf