### PR TITLE
fix: 04-bug-04 unsubscribe logic

### DIFF
--- a/docs/bug-fix/04-bug-04-unsubscribe-logic-error-resolved.md
+++ b/docs/bug-fix/04-bug-04-unsubscribe-logic-error-resolved.md
@@ -1,0 +1,12 @@
+# Bug 04 Resolved - Logic Error in Unsubscribe Client Count Check
+
+The unsubscribe logic checked the number of subscribed clients *before* removing the current client. As a result, the last client leaving a channel never triggered a Delta Exchange unsubscription.
+
+## Fix Summary
+- `handleUnsubscribe` now removes the client first and then checks the remaining client count under a read lock.
+- Introduced `clients.DeltaClient` interface to allow testing with a stub Delta client.
+- Added unit test `TestBug04_Repro` reproducing the issue and verifying the fix.
+
+## Verification
+1. `make ci` completes successfully.
+2. Running `go test ./...` shows `TestBug04_Repro` passes.

--- a/docs/bugs/04-bug-04-unsubscribe-logic-error.md
+++ b/docs/bugs/04-bug-04-unsubscribe-logic-error.md
@@ -3,7 +3,7 @@
 **Bug ID**: 04-bug-04  
 **Discovery Phase**: Phase 2.2  
 **Severity**: Medium  
-**Status**: Open  
+**Status**: Fixed
 **Reporter**: Bug Identification Process  
 **Date Discovered**: 2024-06-24  
 

--- a/internal/clients/delta_client.go
+++ b/internal/clients/delta_client.go
@@ -1,0 +1,12 @@
+package clients
+
+// DeltaClient defines the methods used by WebsocketHandler to interact with a data source like Delta Exchange.
+type DeltaClient interface {
+	Connect() error
+	Close() error
+	Subscribe(channel string, productIDs []string) error
+	Unsubscribe(channel string) error
+	RegisterHandler(channel string, handler MessageHandler)
+	GetConnectionStatus() map[string]interface{}
+	IsConnected() bool
+}

--- a/internal/handlers/testhooks.go
+++ b/internal/handlers/testhooks.go
@@ -1,0 +1,42 @@
+package handlers
+
+import "github.com/consentsam/websocket-integration-challange/internal/clients"
+
+// TestSubscribeClient exposes subscribeClient for tests.
+func (h *WebsocketHandler) TestSubscribeClient(c *Client, channel string, productIDs []string) {
+	h.subscribeClient(c, channel, productIDs)
+}
+
+// TestUnsubscribeClient exposes unsubscribeClient for tests.
+func (h *WebsocketHandler) TestUnsubscribeClient(c *Client, channel string) {
+	h.unsubscribeClient(c, channel)
+}
+
+// TestHandleUnsubscribe exposes handleUnsubscribe for tests.
+func (h *WebsocketHandler) TestHandleUnsubscribe(c *Client, msg map[string]interface{}) {
+	h.handleUnsubscribe(c, msg)
+}
+
+// TestSubscriptionsCount returns the number of clients subscribed to a channel.
+func (h *WebsocketHandler) TestSubscriptionsCount(channel string) int {
+	h.subscriptionsMu.RLock()
+	defer h.subscriptionsMu.RUnlock()
+	if clients, ok := h.subscriptions[channel]; ok {
+		return len(clients)
+	}
+	return 0
+}
+
+// NewTestClient creates a minimal Client for unit tests.
+func NewTestClient() *Client {
+	return &Client{
+		send:           make(chan []byte, 1),
+		subscriptions:  make(map[string]bool),
+		productFilters: make(map[string][]string),
+	}
+}
+
+// GetDeltaClient exposes the current DeltaClient instance.
+func (h *WebsocketHandler) GetDeltaClient() clients.DeltaClient {
+	return h.deltaClient
+}

--- a/internal/handlers/websocket_handler.go
+++ b/internal/handlers/websocket_handler.go
@@ -581,24 +581,21 @@ func (h *WebsocketHandler) handleUnsubscribe(client *Client, msg map[string]inte
 					// Remove the client subscription first
 					h.unsubscribeClient(client, channelName)
 
-					// After removal, check if Delta client should also unsubscribe
+					// After removal, check if Delta client should also unsubscribe (i.e. no remaining clients)
 					if h.deltaClient != nil {
-						if channel, ok := msg["type"].(string); ok {
-							if channel == "unsubscribe" {
-								h.subscriptionsMu.RLock()
-								if clients, ok := h.subscriptions[channelName]; ok {
-									if len(clients) == 0 {
-										h.subscriptionsMu.RUnlock()
-										h.deltaClient.Unsubscribe(channelName)
-									} else {
-										fmt.Println("WS_handler: Delta: still ", len(clients), " clients subscribed to channel: ", channelName)
-										h.subscriptionsMu.RUnlock()
-									}
-								} else {
-									h.subscriptionsMu.RUnlock()
-									h.deltaClient.Unsubscribe(channelName)
-								}
-							}
+						// Determine if any clients remain subscribed to this channel
+						h.subscriptionsMu.RLock()
+						clientsRemaining, hasSubscribers := h.subscriptions[channelName]
+						count := 0
+						if hasSubscribers {
+							count = len(clientsRemaining)
+						}
+						h.subscriptionsMu.RUnlock()
+
+						if !hasSubscribers {
+							h.deltaClient.Unsubscribe(channelName)
+						} else {
+							fmt.Println("WS_handler: Delta: still ", count, " clients subscribed to channel: ", channelName)
 						}
 					}
 				}

--- a/internal/handlers/websocket_handler.go
+++ b/internal/handlers/websocket_handler.go
@@ -43,7 +43,7 @@ type WebsocketHandler struct {
 	subscriptions    map[string]map[*Client]bool
 	subscriptionsMu  sync.RWMutex
 	config           *config.Config
-	deltaClient      *clients.DeltaWebsocketClient
+	deltaClient      clients.DeltaClient
 	ctx              context.Context
 	cancel           context.CancelFunc
 	messagesSent     int64
@@ -140,6 +140,11 @@ func NewWebsocketHandler(ctx context.Context, cfg *config.Config) *WebsocketHand
 	go handler.run()
 
 	return handler
+}
+
+// SetDeltaClient allows injecting a custom Delta client (primarily for tests).
+func (h *WebsocketHandler) SetDeltaClient(dc clients.DeltaClient) {
+	h.deltaClient = dc
 }
 
 // HandleWebsocket handles a websocket connection
@@ -446,13 +451,13 @@ func (h *WebsocketHandler) writePump(client *Client) {
 			for i := 0; i < n; i++ {
 				msg := <-client.send
 				if err := client.conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-				span.RecordError(err)
-				if clientDeliveryTotal != nil {
-					clientDeliveryTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("result", "error")))
+					span.RecordError(err)
+					if clientDeliveryTotal != nil {
+						clientDeliveryTotal.Add(ctx, 1, metric.WithAttributes(attribute.String("result", "error")))
+					}
+					span.End()
+					return
 				}
-				span.End()
-				return
-			}
 				totalBytes += len(msg)
 				atomic.AddInt64(&h.messagesSent, 1)
 			}
@@ -573,25 +578,29 @@ func (h *WebsocketHandler) handleUnsubscribe(client *Client, msg map[string]inte
 
 					chName = channelName
 
+					// Remove the client subscription first
+					h.unsubscribeClient(client, channelName)
+
+					// After removal, check if Delta client should also unsubscribe
 					if h.deltaClient != nil {
 						if channel, ok := msg["type"].(string); ok {
 							if channel == "unsubscribe" {
-								//check if no other subscriptions exist for this channel
+								h.subscriptionsMu.RLock()
 								if clients, ok := h.subscriptions[channelName]; ok {
 									if len(clients) == 0 {
-										// Unsubscribe the client from the channel
+										h.subscriptionsMu.RUnlock()
 										h.deltaClient.Unsubscribe(channelName)
 									} else {
+										fmt.Println("WS_handler: Delta: still ", len(clients), " clients subscribed to channel: ", channelName)
+										h.subscriptionsMu.RUnlock()
 									}
 								} else {
-									// Unsubscribe the client from the channel
+									h.subscriptionsMu.RUnlock()
 									h.deltaClient.Unsubscribe(channelName)
 								}
 							}
 						}
 					}
-					// Subscribe the client to the channel
-					h.unsubscribeClient(client, channelName)
 				}
 			}
 		}

--- a/tests/bugs/04_repro_test.go
+++ b/tests/bugs/04_repro_test.go
@@ -1,0 +1,58 @@
+package handlers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/consentsam/websocket-integration-challange/internal/clients"
+	"github.com/consentsam/websocket-integration-challange/internal/config"
+	handlers "github.com/consentsam/websocket-integration-challange/internal/handlers"
+)
+
+type stubDeltaClient struct {
+	unsubscribed []string
+}
+
+func (s *stubDeltaClient) Connect() error                                      { return nil }
+func (s *stubDeltaClient) Close() error                                        { return nil }
+func (s *stubDeltaClient) Subscribe(channel string, productIDs []string) error { return nil }
+func (s *stubDeltaClient) Unsubscribe(channel string) error {
+	s.unsubscribed = append(s.unsubscribed, channel)
+	return nil
+}
+func (s *stubDeltaClient) RegisterHandler(channel string, handler clients.MessageHandler) {}
+func (s *stubDeltaClient) GetConnectionStatus() map[string]interface{} {
+	return map[string]interface{}{}
+}
+func (s *stubDeltaClient) IsConnected() bool { return true }
+
+func TestBug04_Repro(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Delta.Enabled = false
+	h := handlers.NewWebsocketHandler(context.Background(), cfg)
+	h.SetDeltaClient(&stubDeltaClient{})
+
+	client := handlers.NewTestClient()
+
+	h.TestSubscribeClient(client, "v2/ticker", []string{"all"})
+
+	msg := map[string]interface{}{
+		"type": "unsubscribe",
+		"payload": map[string]interface{}{
+			"channels": []interface{}{
+				map[string]interface{}{"name": "v2/ticker"},
+			},
+		},
+	}
+
+	h.TestHandleUnsubscribe(client, msg)
+
+	if count := h.TestSubscriptionsCount("v2/ticker"); count != 0 {
+		t.Fatalf("subscription should be removed, got %d", count)
+	}
+
+	stub := h.GetDeltaClient().(*stubDeltaClient)
+	if len(stub.unsubscribed) != 1 || stub.unsubscribed[0] != "v2/ticker" {
+		t.Fatalf("delta unsubscribe not called correctly: %#v", stub.unsubscribed)
+	}
+}


### PR DESCRIPTION
## Summary
- fix unsubscribe sequence by removing client before Delta check
- introduce `DeltaClient` interface and test helpers
- add failing reproduction test for bug 04
- mark bug as Fixed and document resolution

## Testing
- `make ci`

------
https://chatgpt.com/codex/tasks/task_e_685bf7662f588322a7f456be65bdd8a2