### PR TITLE
fix: 02-bug-02 missing protoc dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,10 @@ vendor:
 # Protocol Buffers
 .PHONY: proto
 proto:
+	@which $(PROTOC) > /dev/null || (echo "Error: protoc not found. Install with: brew install protobuf (macOS) or sudo apt-get install protobuf-compiler (Ubuntu/Debian)" && exit 1)
 	mkdir -p $(GEN_DIR)
-	protoc --go_out=./gen ./protos/websocket/v1/api.proto  --go-grpc_out=./gen
+	$(PROTOC) --go_out=./gen ./protos/websocket/v1/api.proto --go-grpc_out=./gen
+
 
 # Docker
 .PHONY: docker-build

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ The service can be configured using YAML configuration files in the `config` dir
 - Go plugins for Protocol Buffers
 - Access to the `github.com/Cryptovate-India/server-utils` package
 
+#### Installing protoc
+
+macOS:
+```bash
+brew install protobuf
+```
+
+Ubuntu/Debian:
+```bash
+sudo apt-get install protobuf-compiler
+```
+
 ### Setup
 
 1. Clone the repository

--- a/docs/bug-fix/02-bug-02-missing-protoc-dependency-resolved.md
+++ b/docs/bug-fix/02-bug-02-missing-protoc-dependency-resolved.md
@@ -1,0 +1,13 @@
+# 02-bug-02 Missing Protocol Buffer Compiler Dependency - Resolved
+
+The build process failed when `protoc` was not installed. A check was added to the `Makefile` and installation instructions were documented.
+
+## Verification
+
+1. Temporarily remove `protoc` from `PATH`:
+   ```bash
+   PATH=/usr/bin:/bin make proto
+   ```
+   The command should output `Error: protoc not found` with installation hints and exit with a non-zero status.
+
+2. Install `protoc` using the provided instructions and rerun `make proto`. It should succeed.

--- a/docs/bugs/00-overview_of_bugs.md
+++ b/docs/bugs/00-overview_of_bugs.md
@@ -1,7 +1,7 @@
 # Bug Overview & Index
 
 **Project**: WebSocket Integration Service  
-**Last Updated**: 2024-06-24  
+**Last Updated**: 2025-06-25
 **Total Bugs Found**: 8  
 **Critical**: 1 | **High**: 3 | **Medium**: 4 | **Low**: 0
 
@@ -84,9 +84,9 @@ Phase 7: Final Integration             [          ] 0 bugs
 ### Status Tracking
 | Status | Count | Description |
 |--------|-------|-------------|
-| **🔍 Open** | 0 | Bug identified, not yet addressed |
+| **🔍 Open** | 7 | Bug identified, not yet addressed |
 | **🔄 In Progress** | 0 | Fix in development |
-| **✅ Fixed** | 0 | Fix implemented, awaiting verification |
+| **✅ Fixed** | 1 | Fix implemented, awaiting verification |
 | **✔️ Verified** | 0 | Fix confirmed working |
 | **❌ Won't Fix** | 0 | Bug accepted as limitation or out of scope |
 

--- a/docs/bugs/02-bug-02-missing-protoc-dependency.md
+++ b/docs/bugs/02-bug-02-missing-protoc-dependency.md
@@ -3,7 +3,7 @@
 **Bug ID**: 02-bug-02  
 **Discovery Phase**: Phase 1.2  
 **Severity**: High  
-**Status**: Open  
+**Status**: Fixed
 **Reporter**: Bug Identification Process  
 **Date Discovered**: 2024-06-24  
 
@@ -276,6 +276,7 @@ This dependency issue exists because protoc is an external tool not managed by G
 | Date | Action | Notes |
 |------|--------|-------|
 | 2024-06-24 | Created | Initial bug report during Phase 1.2 analysis |
+| 2025-06-25 | Fixed | Added protoc check and installation docs |
 
 ---
 

--- a/tests/bugs/02_repro_test.go
+++ b/tests/bugs/02_repro_test.go
@@ -1,0 +1,24 @@
+package bugs
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestBug02_Repro verifies the build fails with a helpful error when protoc is missing.
+func TestBug02_Repro(t *testing.T) {
+	if os.Getenv("CI") == "true" {
+		t.Skip("Regression test; passes post-fix")
+	}
+	cmd := exec.Command("bash", "-c", "make PROTOC=nonexistent-protoc proto")
+	cmd.Dir = "../.."
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected make proto to fail without protoc")
+	}
+	if !bytes.Contains(out, []byte("Error: protoc not found")) {
+		t.Fatalf("expected error message about missing protoc, got: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- check for `protoc` in Makefile before generating protos
- document how to install `protoc`
- mark bug 02 as fixed and add resolution notes
- track bug status in overview
- add regression test for missing `protoc`

closes docs/bugs/02-bug-02-missing-protoc-dependency.md

------
https://chatgpt.com/codex/tasks/task_e_685bf78d93ac8322bfeb24767bcabf52