### PR TITLE
fix: 08-bug-08 commented-out subscriptions

### DIFF
--- a/docs/bug-fix/08-bug-08-commented-out-subscriptions-resolved.md
+++ b/docs/bug-fix/08-bug-08-commented-out-subscriptions-resolved.md
@@ -1,0 +1,11 @@
+# 08-bug-08 Commented Out Channel Subscriptions - Resolved
+
+The Delta WebSocket client was connecting without subscribing to any channels because the subscription loop in `Connect()` was commented out. This prevented market data from being received automatically.
+
+## Verification
+1. Added a regression test `TestBug08_Repro` which starts a local WebSocket server and ensures a subscribe message is sent after `Connect()`.
+2. Uncommented the subscription logic in `internal/clients/delta_websocket.go`.
+3. Ran `make ci` to confirm build, lint, and tests all pass.
+
+## Result
+`Connect()` now automatically subscribes to configured channels and the regression test passes.

--- a/docs/bugs/08-bug-08-commented-out-subscriptions.md
+++ b/docs/bugs/08-bug-08-commented-out-subscriptions.md
@@ -3,7 +3,7 @@
 **Bug ID**: 08-bug-08  
 **Discovery Phase**: Phase 3.2  
 **Severity**: High  
-**Status**: Open  
+**Status**: Fixed  
 **Reporter**: Bug Identification Process  
 **Date Discovered**: 2024-06-24  
 

--- a/internal/clients/delta_websocket.go
+++ b/internal/clients/delta_websocket.go
@@ -112,13 +112,13 @@ func (c *DeltaWebsocketClient) Connect() error {
 	// Start the read pump
 	go c.readPump()
 
-	// // Subscribe to channels (without holding the lock)
-	// for _, channel := range c.channels {
-	// 	fmt.Println("Delta_WS: Connect: Subscribing to channel:", channel)
-	// 	if err := c.Subscribe(channel, c.productIDs); err != nil {
-	// 		log.Printf("Failed to subscribe to channel %s: %v", channel, err)
-	// 	}
-	// }
+	// Subscribe to channels (without holding the lock)
+	for _, channel := range c.channels {
+		fmt.Println("Delta_WS: Connect: Subscribing to channel:", channel)
+		if err := c.Subscribe(channel, c.productIDs); err != nil {
+			log.Printf("Failed to subscribe to channel %s: %v", channel, err)
+		}
+	}
 
 	return nil
 }

--- a/tests/bugs/08_repro_test.go
+++ b/tests/bugs/08_repro_test.go
@@ -1,0 +1,77 @@
+package bugs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/consentsam/websocket-integration-challange/internal/clients"
+	"github.com/consentsam/websocket-integration-challange/internal/config"
+)
+
+// TestBug08_Repro verifies that Connect automatically subscribes to channels.
+func TestBug08_Repro(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short")
+	}
+
+	// Channel to capture the first message from client
+	msgCh := make(chan []byte, 1)
+
+	// Start a local websocket server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		up := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade error: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read message error: %v", err)
+			return
+		}
+		msgCh <- msg
+		// Keep connection open briefly to avoid client errors
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + srv.URL[len("http"):] // convert http://127.0.0.1 -> ws://127.0.0.1
+
+	cfg := &config.Delta{
+		Enabled:      true,
+		URL:          wsURL,
+		Channels:     []string{"v2/ticker"},
+		ProductIDs:   []string{"BTCUSD"},
+		ReconnectMax: 1,
+	}
+
+	client := clients.NewDeltaWebsocketClient(context.Background(), cfg)
+
+	if err := client.Connect(); err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+
+	select {
+	case raw := <-msgCh:
+		var m map[string]interface{}
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("invalid json: %v", err)
+		}
+		if m["type"] != "subscribe" {
+			t.Fatalf("expected subscribe message, got %v", m["type"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no message received")
+	}
+
+	client.Close()
+}


### PR DESCRIPTION
## Summary
- restore automatic channel subscriptions in Delta client
- add regression test for Delta client subscriptions
- document fix

Closes docs/bugs/08-bug-08-commented-out-subscriptions.md


------
https://chatgpt.com/codex/tasks/task_e_685bf8c30e888322b8d2f92ec8288e0a