### PR TITLE
fix: 09-bug-09 race in broadcast

### DIFF
--- a/docs/bug-fix/09-bug-09-race-condition-broadcast-subscription-access-resolved.md
+++ b/docs/bug-fix/09-bug-09-race-condition-broadcast-subscription-access-resolved.md
@@ -1,0 +1,18 @@
+# 09-bug-09 Race Condition in BroadcastToChannel Subscription Access - Resolved
+
+Concurrent modifications to the subscription map could occur while broadcasting
+messages. `BroadcastToChannel` copied the reference to the clients map while
+holding only a read lock, then iterated without any synchronization. This led to
+concurrent map writes and panics under the race detector.
+
+## Verification
+1. Added regression test `TestBug09_Repro` that runs broadcasts and unsubscriptions
+   concurrently. Prior to the fix, the race detector reports a data race.
+2. Updated `BroadcastToChannel` to copy the subscribed clients while the
+   subscription lock is held and verify membership before sending.
+3. `make ci` confirms all tests pass with the race detector enabled.
+
+## Result
+Broadcasting to a channel no longer races with subscription updates and tests pass
+cleanly under `-race`.
+

--- a/docs/bugs-phase-02/09-bug-09-race-condition-broadcast-subscription-access.md
+++ b/docs/bugs-phase-02/09-bug-09-race-condition-broadcast-subscription-access.md
@@ -3,7 +3,7 @@
 **Bug ID**: 09-bug-09  
 **Discovery Phase**: Phase 2.3 - Advanced Concurrency & Race Analysis  
 **Severity**: Critical  
-**Status**: Open  
+**Status**: Fixed  
 **Reporter**: Phase 2 Verification Analysis  
 **Date Discovered**: 2024-12-19  
 

--- a/internal/handlers/websocket_handler.go
+++ b/internal/handlers/websocket_handler.go
@@ -178,13 +178,18 @@ func (h *WebsocketHandler) HandleWebsocket(w http.ResponseWriter, r *http.Reques
 // BroadcastToChannel broadcasts a message to all clients subscribed to a channel
 func (h *WebsocketHandler) BroadcastToChannel(channel string, message []byte, productID string) {
 
-	// Get the clients subscribed to the channel
+	// Safely copy the subscribed clients for iteration
 	h.subscriptionsMu.RLock()
-	clients, ok := h.subscriptions[channel]
-	h.subscriptionsMu.RUnlock()
+	clientsMap, ok := h.subscriptions[channel]
 	if !ok {
+		h.subscriptionsMu.RUnlock()
 		return
 	}
+	clientsCopy := make([]*Client, 0, len(clientsMap))
+	for c := range clientsMap {
+		clientsCopy = append(clientsCopy, c)
+	}
+	h.subscriptionsMu.RUnlock()
 
 	var span trace.Span
 	ctx := h.ctx
@@ -193,7 +198,14 @@ func (h *WebsocketHandler) BroadcastToChannel(channel string, message []byte, pr
 	start = time.Now()
 
 	// Broadcast the message to all clients subscribed to the channel
-	for client := range clients {
+	for _, client := range clientsCopy {
+		// Ensure the client is still subscribed
+		h.subscriptionsMu.RLock()
+		if _, still := h.subscriptions[channel][client]; !still {
+			h.subscriptionsMu.RUnlock()
+			continue
+		}
+		h.subscriptionsMu.RUnlock()
 		// Check if the client has a product filter for the channel
 		client.mu.RLock()
 		clientProductIDs, hasFilter := client.productFilters[channel]

--- a/internal/handlers/websocket_handler.go
+++ b/internal/handlers/websocket_handler.go
@@ -201,7 +201,12 @@ func (h *WebsocketHandler) BroadcastToChannel(channel string, message []byte, pr
 	for _, client := range clientsCopy {
 		// Ensure the client is still subscribed
 		h.subscriptionsMu.RLock()
-		if _, still := h.subscriptions[channel][client]; !still {
+		channelClients, channelExists := h.subscriptions[channel]
+		if !channelExists {
+			h.subscriptionsMu.RUnlock()
+			continue
+		}
+		if _, still := channelClients[client]; !still {
 			h.subscriptionsMu.RUnlock()
 			continue
 		}

--- a/tests/bugs/09_repro_test.go
+++ b/tests/bugs/09_repro_test.go
@@ -1,0 +1,50 @@
+package bugs
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/consentsam/websocket-integration-challange/internal/config"
+	handlers "github.com/consentsam/websocket-integration-challange/internal/handlers"
+)
+
+// TestBug09_Repro triggers the race condition in BroadcastToChannel when
+// subscriptions are modified concurrently.
+func TestBug09_Repro(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := config.LoadConfig("websocket-service")
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	cfg.Delta.Enabled = false
+
+	h := handlers.NewWebsocketHandler(ctx, cfg)
+
+	clients := make([]*handlers.Client, 100)
+	for i := range clients {
+		c := handlers.NewTestClient()
+		clients[i] = c
+		h.RegisterClientForTest(c)
+		h.TestSubscribeClient(c, "test", []string{"p1"})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			h.BroadcastToChannel("test", []byte("m"), "p1")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			h.TestUnsubscribeClient(clients[i], "test")
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- add failing test for concurrent subscription access
- fix BroadcastToChannel to copy subscriptions while locked
- document fix
- mark bug 09 as Fixed

closes docs/bugs-phase-02/09-bug-09-race-condition-broadcast-subscription-access.md


------
https://chatgpt.com/codex/tasks/task_e_685c3a2d97188322bea3f773c6e5f9a8